### PR TITLE
Added support for correct public address generation

### DIFF
--- a/src/main/java/io/horizontalsystems/hdwalletkit/HDKey.java
+++ b/src/main/java/io/horizontalsystems/hdwalletkit/HDKey.java
@@ -115,13 +115,19 @@ public class HDKey extends ECKey {
      * Serialize public key to Base58 ("xpub" )
      * @return the key serialized as a Base58 address
      */
-    public String serializePubB58() {
-        return toBase58(serializePub());
+    public String serializePubB58(HDWallet.Purpose purpose, PublicAddressType type) {
+        for(PublicAddressType addrType: purpose.getPubAddressType()) {
+            if(addrType == type) {
+                return toBase58(serializePub(addrType.getPublicMagicBytes()));
+            }
+        }
+
+        throw new IllegalArgumentException("Unsupported public address type: " + type);
     }
 
-    private byte[] serializePub() {
+    private byte[] serializePub(int publicMagicBytes) {
         ByteBuffer ser = ByteBuffer.allocate(78);
-        ser.putInt(0x0488b21e); //The 4 byte header that serializes in base58 to "xpub"
+        ser.putInt(publicMagicBytes);
         ser.put((byte) getDepth());
         ser.putInt(getParentFingerprint());
         ser.putInt(getChildNumberEncoded());
@@ -130,6 +136,7 @@ public class HDKey extends ECKey {
         if(ser.position() != 78){
             throw new IllegalStateException();
         }
+
         return ser.array();
     }
 

--- a/src/main/kotlin/io/horizontalsystems/hdwalletkit/HDWallet.kt
+++ b/src/main/kotlin/io/horizontalsystems/hdwalletkit/HDWallet.kt
@@ -36,7 +36,7 @@ class HDWallet(seed: ByteArray, private val coinType: Int, val gapLimit: Int = 2
     }
 
     fun hdPublicKeys(account: Int, indices: IntRange, external: Boolean): List<HDPublicKey> {
-        val parentPrivateKey = privateKey("m/${purpose.value}'/$coinType'/$account'/${if (external) 0 else 1}") // todo: this may be a bug they are missing the last ' in the path same for others below
+        val parentPrivateKey = privateKey("m/${purpose.value}'/$coinType'/$account'/${if (external) 0 else 1}")
         return hdKeychain
             .deriveNonHardenedChildKeys(parentPrivateKey, indices)
             .map {

--- a/src/main/kotlin/io/horizontalsystems/hdwalletkit/PublicAddressType.kt
+++ b/src/main/kotlin/io/horizontalsystems/hdwalletkit/PublicAddressType.kt
@@ -1,0 +1,25 @@
+package io.horizontalsystems.hdwalletkit
+
+enum class PublicAddressType(
+    val publicMagicBytes: Int,
+    val privateMagicBytes: Int
+) {
+
+    // -- Bitcoin Regin Begin
+    /* Main Net Pub Address Bytes */
+    P2PKH(0x0488b21e, 0x0488ade4), // xpub, xprv
+    P2WPKH_P2SH(0x049d7cb2, 0x049d7878), // ypub, ypriv
+    P2WSH_P2SH(0x0295b43f, 0x0295b005), // Ypub, Ypriv
+    P2WPKH(0x04b24746, 0x04b2430c), // zpub, zpriv
+    P2WSH(0x02aa7ed3, 0x02aa7a99), // Zpub. Zpriv
+    /* ========================= */
+
+    /* Test Net Pub Address Bytes */
+    TEST_P2PKH(0x043587cf, 0x04358394), // tpub, tpriv
+    TEST_P2WPKH_P2SH(0x044a5262, 0x044a4e28), // upub, upriv
+    TEST_P2WSH_P2SH(0x024289ef, 0x024285b5), // Upub, Upriv
+    TEST_P2WPKH(0x045f1cf6, 0x045f18bc), // vpub, vpriv
+    TEST_P2WSH(0x02575483, 0x02575048); // Vpub, Vpriv
+    /* ========================= */
+    // -- Bitcoin Regin End
+}


### PR DESCRIPTION
This adds support for correct public address generation for bitcoin wallets.

[!] Please note this has only been tested on bitcoin wallets and not other networks. Nonetheless, this fixes an issue that was incorrectly generating a public address for a given wallet and adds a helpful master public ket function to be used for convience.